### PR TITLE
Customized turbolinks session class

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
@@ -47,4 +47,6 @@ public interface TurbolinksAdapter {
      * @param action Whether to treat the request as an advance (navigating forward) or a replace (back).
      */
     void visitProposedToLocationWithAction(String location, String action);
+
+    void hideProgressViewAnimation();
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -540,10 +540,15 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
                  */
                 if (turbolinksIsReady && TextUtils.equals(visitIdentifier, currentVisitIdentifier)) {
                     TurbolinksLog.d("Hiding progress view for visitIdentifier: " + visitIdentifier + ", currentVisitIdentifier: " + currentVisitIdentifier);
-                    turbolinksView.hideProgress();
+                    turbolinksAdapter.hideProgressViewAnimation();
                 }
             }
         });
+    }
+
+    @android.webkit.JavascriptInterface
+    public void hideProgress() {
+        turbolinksView.hideProgress();
     }
 
     /**


### PR DESCRIPTION
Rewrite hideProgressView(). We can subclass TurbolinksAdapter and provide animation before removing progressView.

See https://github.com/starburstlabs/wealthbase-android/pull/69